### PR TITLE
[BE] Label 선택용 목록 조회 API 구현

### DIFF
--- a/be/issue-tracker/src/main/java/org/presents/issuetracker/label/controller/LabelController.java
+++ b/be/issue-tracker/src/main/java/org/presents/issuetracker/label/controller/LabelController.java
@@ -4,9 +4,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.presents.issuetracker.global.dto.response.LabelResponse;
 import org.presents.issuetracker.label.dto.request.LabelCreateRequest;
 import org.presents.issuetracker.label.dto.request.LabelUpdateRequest;
+import org.presents.issuetracker.label.dto.response.LabelPreviewResponse;
 import org.presents.issuetracker.label.service.LabelService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -17,6 +20,12 @@ public class LabelController {
 
     public LabelController(LabelService labelService) {
         this.labelService = labelService;
+    }
+
+    @GetMapping("/previews")
+    public ResponseEntity<List<LabelPreviewResponse>> getLabelPreviews() {
+        List<LabelPreviewResponse> labelPreviews = labelService.getLabels();
+        return ResponseEntity.ok().body(labelPreviews);
     }
 
     @PostMapping
@@ -30,5 +39,4 @@ public class LabelController {
         LabelResponse labelResponse = labelService.update(dto);
         return ResponseEntity.ok().body(labelResponse);
     }
-
 }

--- a/be/issue-tracker/src/main/java/org/presents/issuetracker/label/dto/request/LabelCreateRequest.java
+++ b/be/issue-tracker/src/main/java/org/presents/issuetracker/label/dto/request/LabelCreateRequest.java
@@ -2,10 +2,8 @@ package org.presents.issuetracker.label.dto.request;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 public class LabelCreateRequest {
     private String name;
     private String description;

--- a/be/issue-tracker/src/main/java/org/presents/issuetracker/label/dto/request/LabelUpdateRequest.java
+++ b/be/issue-tracker/src/main/java/org/presents/issuetracker/label/dto/request/LabelUpdateRequest.java
@@ -1,7 +1,6 @@
 package org.presents.issuetracker.label.dto.request;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 public class LabelUpdateRequest {

--- a/be/issue-tracker/src/main/java/org/presents/issuetracker/label/dto/response/LabelPreviewResponse.java
+++ b/be/issue-tracker/src/main/java/org/presents/issuetracker/label/dto/response/LabelPreviewResponse.java
@@ -1,0 +1,20 @@
+package org.presents.issuetracker.label.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class LabelPreviewResponse {
+    private long id;
+    private String name;
+    private String textColor;
+    private String backgroundColor;
+
+    @Builder
+    public LabelPreviewResponse(long id, String name, String textColor, String backgroundColor) {
+        this.id = id;
+        this.name = name;
+        this.textColor = textColor;
+        this.backgroundColor = backgroundColor;
+    }
+}

--- a/be/issue-tracker/src/main/java/org/presents/issuetracker/label/dto/response/LabelResponse.java
+++ b/be/issue-tracker/src/main/java/org/presents/issuetracker/label/dto/response/LabelResponse.java
@@ -1,4 +1,0 @@
-package org.presents.issuetracker.label.dto.response;
-
-public class LabelResponse {
-}

--- a/be/issue-tracker/src/main/java/org/presents/issuetracker/label/entity/Label.java
+++ b/be/issue-tracker/src/main/java/org/presents/issuetracker/label/entity/Label.java
@@ -22,6 +22,13 @@ public class Label {
         this.textColor = textColor;
     }
 
+    private Label(Long id, String name, String backgroundColor, String textColor) {
+        this.id = id;
+        this.name = name;
+        this.backgroundColor = backgroundColor;
+        this.textColor = textColor;
+    }
+
     private Label(String name, String description, String backgroundColor, String textColor) {
         this.name = name;
         this.description = description;
@@ -30,10 +37,16 @@ public class Label {
     }
 
     public static Label of(Long id, String name, String description, String backgroundColor, String textColor) {
-        return new Label(id, name, description, backgroundColor, textColor);}
+        return new Label(id, name, description, backgroundColor, textColor);
+    }
+
+    public static Label of(Long id, String name, String backgroundColor, String textColor) {
+        return new Label(id, name, backgroundColor, textColor);
+    }
 
     public static Label of(String name, String description, String backgroundColor, String textColor) {
-        return new Label(name, description, backgroundColor, textColor);}
+        return new Label(name, description, backgroundColor, textColor);
+    }
 
     public Label updateFrom(LabelUpdateRequest dto) {
         if (!Objects.equals(this.name, dto.getName())) {

--- a/be/issue-tracker/src/main/java/org/presents/issuetracker/label/service/LabelService.java
+++ b/be/issue-tracker/src/main/java/org/presents/issuetracker/label/service/LabelService.java
@@ -3,9 +3,13 @@ package org.presents.issuetracker.label.service;
 import org.presents.issuetracker.global.dto.response.LabelResponse;
 import org.presents.issuetracker.label.dto.request.LabelCreateRequest;
 import org.presents.issuetracker.label.dto.request.LabelUpdateRequest;
+import org.presents.issuetracker.label.dto.response.LabelPreviewResponse;
 import org.presents.issuetracker.label.entity.Label;
 import org.presents.issuetracker.label.repository.LabelRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class LabelService {
@@ -14,6 +18,18 @@ public class LabelService {
 
     public LabelService(LabelRepository labelRepository) {
         this.labelRepository = labelRepository;
+    }
+
+    public List<LabelPreviewResponse> getLabels() {
+        List<Label> labels = labelRepository.findAll();
+
+        return labels.stream().map(label -> LabelPreviewResponse.builder()
+                        .id(label.getId())
+                        .name(label.getName())
+                        .backgroundColor(label.getBackgroundColor())
+                        .textColor(label.getTextColor())
+                        .build())
+                .collect(Collectors.toList());
     }
 
     public LabelResponse create(LabelCreateRequest labelCreateRequest) {


### PR DESCRIPTION
## What is this PR? 👓
* Label 선택용 목록 조회 로직을 구현했습니다.

## Key changes 🔑
* 프론트엔드 요청에 따라, `Repository.findAll()` 의 쿼리에서 `레이블 필터`의 `레이블 없는 이슈`를 표시하기 위해 id가 0인 row를 추가해 반환합니다.

## To reviewers 👋
