### PR TITLE
[FE] feat: 로그인, 회원가입 UI (#89)

### DIFF
--- a/fe/src/components/common/sideBar/ListSideBar.tsx
+++ b/fe/src/components/common/sideBar/ListSideBar.tsx
@@ -190,7 +190,7 @@ export const ListSideBar: React.FC<Props> = ({
           indicator="마일스톤"
           size="L"
           isPanelOpen={isPanelOpen === 'milestones'}
-          onClick={() => openPanel(getLabels, 'labels')}
+          onClick={() => openPanel(getMilestones, 'milestones')}
         >
           <DropDownPanel
             panelHeader="마일스톤 설정"

--- a/fe/src/components/common/textArea/AddButtons.tsx
+++ b/fe/src/components/common/textArea/AddButtons.tsx
@@ -1,13 +1,6 @@
 import { useTheme } from '@emotion/react';
 import { ErrorMessages } from './ErrorMessages';
 
-type DefaultFileStatusType = {
-  typeError: boolean;
-  sizeError: boolean;
-  isUploading: boolean;
-  uploadFailed: boolean;
-};
-
 type Props = {
   onFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   fileStatus: DefaultFileStatusType;

--- a/fe/src/components/signPage/LoginForm.tsx
+++ b/fe/src/components/signPage/LoginForm.tsx
@@ -1,0 +1,72 @@
+import { useTheme } from '@emotion/react';
+import { Button } from '@components/common/Button';
+import { TextInput } from '@components/common/textInput/TextInput';
+// import { useState } from 'react';
+
+export const LoginForm: React.FC = () => {
+  const theme = useTheme() as any;
+  // const [id, setId] = useState('');
+  // const [password, setPassword] = useState('');
+
+  return (
+    <form action="">
+      <div
+        css={{
+          width: '320px',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <TextInput
+          value=""
+          label="아이디"
+          height={56}
+          inputType="text"
+          placeholder="아이디"
+          isError={true}
+          captionString="아이디는 6자 이상 16자 이하로 입력해주세요."
+          onChange={() => console.log('id입력')}
+        />
+        <TextInput
+          value=""
+          label="비밀번호"
+          height={56}
+          inputType="password"
+          placeholder="비밀번호"
+          isError={false}
+          captionString="비밀번호는 6자 이상 12자 이하로 입력해주세요."
+          onChange={() => console.log('pw입력')}
+        />
+        <div
+          css={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '16px',
+          }}
+        >
+          <Button
+            typeVariant="contained"
+            size="L"
+            disabled={true}
+            css={{
+              width: '100%',
+              borderRadius: theme.radius.l,
+            }}
+          >
+            아이디로 로그인
+          </Button>
+          <Button
+            typeVariant="ghost"
+            size="L"
+            css={{
+              width: '100%',
+              borderRadius: theme.radius.l,
+            }}
+          >
+            회원가입
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
+};

--- a/fe/src/components/signPage/OAuthButton.tsx
+++ b/fe/src/components/signPage/OAuthButton.tsx
@@ -1,3 +1,21 @@
+import { useTheme } from '@emotion/react';
+import { Button } from '@components/common/Button';
+
 export const OAuthButton: React.FC = () => {
-  return <></>;
+  const theme = useTheme() as any;
+
+  return (
+    <>
+      <Button
+        typeVariant="outline"
+        size="L"
+        css={{
+          width: '320px',
+          borderRadius: theme.radius.l,
+        }}
+      >
+        GitHub 계정으로 로그인
+      </Button>
+    </>
+  );
 };

--- a/fe/src/components/signPage/RegisterForm.tsx
+++ b/fe/src/components/signPage/RegisterForm.tsx
@@ -1,0 +1,189 @@
+import { useTheme } from '@emotion/react';
+import { Button } from '@components/common/Button';
+import { TextInput } from '@components/common/textInput/TextInput';
+// import { useState } from 'react';
+import { ReactComponent as Plus } from '@assets/icons/plus.svg';
+
+export const RegisterForm: React.FC = () => {
+  // const availableFileSize = 1048576; //1MB
+  const theme = useTheme() as any;
+  // const [id, setId] = useState('');
+  // const [password, setPassword] = useState('');
+
+  // textArea와 중복되는 코드 줄이기
+  // const [uploadedProfile, setUploadedProfile] = useState<string | null>(null);
+
+  // const [fileStatus, setFileStatus] = useState<DefaultFileStatusType>({
+  //   typeError: false,
+  //   sizeError: false,
+  //   isUploading: false,
+  //   uploadFailed: false,
+  // });
+
+  // const profile = uploadedProfile
+  //   ? uploadedProfile
+  //   : 'https://avatars.githubusercontent.com/u/180050?v=4';
+
+  // const uploadImage = async (file: File) => {
+  //   try {
+  //     setFileStatus((prev) => ({ ...prev, isUploading: true }));
+
+  //     const formData = new FormData();
+  //     formData.append('file', file);
+
+  //     const response = await fetch(`/{경로}`, {
+  //       method: 'POST',
+  //       body: formData,
+  //     });
+
+  //     if (!response.ok) {
+  //       throw new Error('File upload failed');
+  //     }
+
+  //     const data = await response.json();
+  //     setUploadedProfile(data.url);
+  //     return data;
+  //   } catch (error) {
+  //     setFileStatus((prev) => ({ ...prev, uploadFailed: true }));
+  //   } finally {
+  //     setFileStatus((prev) => ({ ...prev, isUploading: false }));
+  //   }
+  // };
+
+  return (
+    <>
+      <form action="">
+        <div
+          css={{
+            width: '320px',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+          }}
+        >
+          <div
+            css={{
+              position: 'relative',
+              marginBottom: '40px',
+            }}
+          >
+            <img
+              // src={profile}
+              alt="유저 프로필"
+              css={{
+                borderRadius: theme.radius.half,
+                display: 'block',
+                width: '200px',
+                height: '200px',
+                // background: profile
+                //   ? 'transparent'
+                //   : theme.neutral.surface.bold,
+              }}
+            />
+            <label
+              htmlFor="file"
+              css={{
+                marginLeft: '-16px',
+                background: 'transparent',
+                cursor: 'pointer',
+                '&:active': {
+                  opacity: theme.opacity.press,
+                },
+              }}
+            >
+              <div
+                css={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: '56px',
+                  height: '56px',
+                  borderRadius: theme.radius.half,
+                  position: 'absolute',
+                  right: '0px',
+                  bottom: '10px',
+                  background: theme.palette.blue,
+                  transition: 'transform 0.3s',
+                  '&:hover': {
+                    transform: 'scale(1.1)',
+                  },
+                }}
+              >
+                <Plus stroke={theme.neutral.surface.strong} />
+              </div>
+            </label>
+            <input
+              onChange={() => console.log('프로필 사진 업로드')}
+              type="file"
+              id="file"
+              css={{ display: 'none' }}
+              aria-label="프로필 사진 업로드"
+            />
+          </div>
+          <div css={{ display: 'flex', gap: '8px' }}>
+            <TextInput
+              value=""
+              label="아이디"
+              height={56}
+              inputType="text"
+              placeholder="아이디"
+              isError={true}
+              captionString="아이디는 6자 이상 16자 이하로 입력해주세요."
+              onChange={() => console.log('id입력')}
+            />
+            <Button
+              typeVariant="ghost"
+              size="M"
+              css={{
+                width: 'fit-content',
+                whiteSpace: 'nowrap',
+                padding: '0',
+              }}
+            >
+              중복체크
+            </Button>
+          </div>
+          <TextInput
+            value=""
+            label="비밀번호"
+            height={56}
+            inputType="password"
+            placeholder="비밀번호"
+            isError={false}
+            captionString="비밀번호는 6자 이상 12자 이하로 입력해주세요."
+            onChange={() => console.log('pw입력')}
+          />
+          <TextInput
+            value=""
+            label="비밀번호 확인"
+            height={56}
+            inputType="password"
+            placeholder="비밀번호 확인"
+            isError={false}
+            captionString="비밀번호가 일치하지 않습니다."
+            onChange={() => console.log('pw확인 입력')}
+          />
+          <div
+            css={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '16px',
+            }}
+          >
+            <Button
+              typeVariant="contained"
+              size="L"
+              disabled={true}
+              css={{
+                width: '320px',
+                borderRadius: theme.radius.l,
+              }}
+            >
+              회원가입
+            </Button>
+          </div>
+        </div>
+      </form>
+    </>
+  );
+};

--- a/fe/src/components/signPage/SignForm.tsx
+++ b/fe/src/components/signPage/SignForm.tsx
@@ -1,8 +1,0 @@
-// import { useState } from 'react';
-
-// const SignForm: React.FC = () => {
-//   const [id, setId] = useState('');
-//   const [password, setPassword] = useState('');
-
-//   return <></>;
-// };

--- a/fe/src/pages/RegisterPage.tsx
+++ b/fe/src/pages/RegisterPage.tsx
@@ -1,21 +1,19 @@
 import { useTheme } from '@emotion/react';
 // import { useState } from 'react';
 
-import { OAuthButton } from '@components/signPage/OAuthButton';
-import { LoginForm } from '@components/signPage/LoginForm';
 import { ReactComponent as LargeLogo } from '@assets/logos/largeLogo.svg';
+import { RegisterForm } from '@components/signPage/RegisterForm';
 
 type Props = {};
 
-export const SignPage: React.FC<Props> = () => {
+export const RegisterPage: React.FC<Props> = () => {
   const theme = useTheme() as any;
-  // const [isSignError, setIsSignError] = useState(false);
+  // const [isRegisterError, setIsRegisterError] = useState(false);
 
   return (
     <>
       <div
         css={{
-          border: '1px solid black',
           width: '100%',
           height: '100vh',
           display: 'flex',
@@ -28,19 +26,11 @@ export const SignPage: React.FC<Props> = () => {
         <div css={{ height: 'fit-content', marginBottom: '48px' }}>
           <LargeLogo fill={theme.neutral.text.strong} />
         </div>
-        <OAuthButton />
-        <span
-          css={{
-            font: theme.fonts.displayMedium16,
-            color: theme.neutral.text.weak,
-          }}
-        >
-          or
-        </span>
-        <LoginForm />
-        {/* {isSignError && (
+
+        <RegisterForm />
+        {/* {isRegisterError && (
           <span css={{ color: theme.danger.text.default }}>
-            실패사유 다시 시도해 주세요
+            {'실패사유'} 다시 시도해 주세요
           </span>
         )} */}
       </div>

--- a/fe/src/routes.tsx
+++ b/fe/src/routes.tsx
@@ -1,11 +1,14 @@
 import { Route, Routes } from 'react-router-dom';
+import { SignPage } from '@pages/SignPage';
+import { RegisterPage } from '@pages/RegisterPage';
 import { Header } from '@components/header/Header';
-import { AddIssuePage } from '@pages/AddIssuePage';
-import { IssueDetailPage } from '@pages/IssueDetailPage';
 import { IssueListPage } from '@pages/IssueListPage';
+import { IssueDetailPage } from '@pages/IssueDetailPage';
+import { AddIssuePage } from '@pages/AddIssuePage';
+
 // import { LabelListPage } from '@pages/LabelListPage';
 // import { MileStoneListPage } from '@pages/MileStoneListPage';
-// import { SignPage } from '@pages/SignPage';
+
 import { NotFoundPage } from '@pages/NotFoundPage';
 import {
   ADD_ISSUE_PAGE,
@@ -23,7 +26,8 @@ type Props = {
 export const AppRoutes: React.FC<Props> = ({ currentTheme, toggleTheme }) => {
   return (
     <Routes>
-      {/* <Route path="/sign" element={<SignPage />} /> */}
+      <Route path="/sign" element={<SignPage />} />
+      <Route path="/register" element={<RegisterPage />} />
       <Route path="/" element={<Header {...{ currentTheme, toggleTheme }} />}>
         <Route path={ISSUE_LIST_PAGE} element={<IssueListPage />} />
         <Route path={`${ISSUE_LIST_PAGE}/:query`} element={<IssueListPage />} />

--- a/fe/src/types/custom.d.ts
+++ b/fe/src/types/custom.d.ts
@@ -34,3 +34,10 @@ type Issue = {
   createdAt: string;
   isOpen: boolean;
 };
+
+type DefaultFileStatusType = {
+  typeError: boolean;
+  sizeError: boolean;
+  isUploading: boolean;
+  uploadFailed: boolean;
+};


### PR DESCRIPTION
## What is this PR? 👓
로그인, 회원가입 UI 구현
## Key changes 🔑

## To reviewers 👋
- 회원가입 페이지와 라우트 추가했습니다 
 - 회원가입 페이지의 사용자 프로필 업로드(파일 업로드) 로직은 textarea의 로직과 동일하여 중복인 상태입니다
 - 추후 기능개발시 개선할 예정입니다
- build시 에러나는 부분 미리 주석처리 했습니다